### PR TITLE
Add 32-bit integers for forward / reverse energy

### DIFF
--- a/attributes.csv
+++ b/attributes.csv
@@ -261,6 +261,12 @@ com.victronenergy.grid,/Ac/L2/Voltage,d,V AC,2618,uint16,10,R
 com.victronenergy.grid,/Ac/L2/Current,d,A AC,2619,int16,10,R
 com.victronenergy.grid,/Ac/L3/Voltage,d,V AC,2620,uint16,10,R
 com.victronenergy.grid,/Ac/L3/Current,d,A AC,2621,int16,10,R
+com.victronenergy.grid,/Ac/L1/Energy/Forward,d,kWh,2622,uint32,100,R
+com.victronenergy.grid,/Ac/L2/Energy/Forward,d,kWh,2624,uint32,100,R
+com.victronenergy.grid,/Ac/L3/Energy/Forward,d,kWh,2626,uint32,100,R
+com.victronenergy.grid,/Ac/L1/Energy/Reverse,d,kWh,2628,uint32,100,R
+com.victronenergy.grid,/Ac/L2/Energy/Reverse,d,kWh,2630,uint32,100,R
+com.victronenergy.grid,/Ac/L3/Energy/Reverse,d,kWh,2632,uint32,100,R
 com.victronenergy.settings,/Settings/CGwacs/AcPowerSetPoint,d,W,2700,int16,1,W
 com.victronenergy.settings,/Settings/CGwacs/AcPowerSetPoint,d,W,2703,int16,0.01,W
 com.victronenergy.settings,/Settings/CGwacs/MaxChargePercentage,d,%,2701,uint16,1,W


### PR DESCRIPTION
Fixes a bug where the total amount of measure energy can never exceed 653.36 kWh, and causes a integer overflow. In this case the integer overflow would occur only at 42 949 672.96 kWh, which is much more reasonable.

Note, this code is not tested, since I have no compilation environment.
[Modbus_Bug_Mail_Conversation.pdf](https://github.com/victronenergy/dbus_modbustcp/files/2209627/Modbus_Bug_Mail_Conversation.pdf)

