### PR TITLE
New registers 2711 and 2712 in com.victronenergy.settings for AcInput

### DIFF
--- a/attributes.csv
+++ b/attributes.csv
@@ -344,6 +344,8 @@ com.victronenergy.settings,/Settings/CGwacs/OvervoltageFeedIn,i,0=Don't feed exc
 com.victronenergy.settings,/Settings/CGwacs/PreventFeedback,i,0=Feed excess AC-coupled PV into grid;1=Don't feed excess AC-coupled PV into the grid,2708,uint16,1,W
 com.victronenergy.settings,/Settings/SystemSetup/MaxChargeVoltage,d,V,2710,uint16,10,W
 com.victronenergy.hub4,/PvPowerLimiterActive,i,0=Feed-in limiting inactive;1=Feed-in limiting active,2709,uint16,1,R
+com.victronenergy.settings,/Settings/SystemSetup/AcInput1,u,0=Unused;1=Grid;2=Genset;3=Shore,2711,uint16,1,W
+com.victronenergy.settings,/Settings/SystemSetup/AcInput2,u,0=Unused;1=Grid;2=Genset;3=Shore,2712,uint16,1,W
 com.victronenergy.tank,/ProductId,u,,3000,uint16,1,R
 com.victronenergy.tank,/Capacity,d,m3,3001,uint32,10000,R
 com.victronenergy.tank,/FluidType,u,0=Fuel;1=Fresh water;2=Waste water;3=Live well;4=Oil;5=Black water (sewage);6=Gasoline;7=Diesel;8=LPG;9=LNG;10=Hydraulic oil;11=Raw water,3003,uint16,1,R


### PR DESCRIPTION
New registers 2711 and 2712 in com.victronenergy.settings for AcInput source types

Access to these settings is already possible through MQTT but has been missing so far for modbustcp.

Tried to figure out reasonable ID numbers. Feel free to change them if they don't match the numbering scheme.