### PR TITLE
Fix #1589: Prevent crash when fetching registers beyond map end

### DIFF
--- a/attributes.csv
+++ b/attributes.csv
@@ -450,7 +450,7 @@ com.victronenergy.settings,/Settings/CGwacs/AcPowerSetPoint,d,W,2700,int16,1,W
 com.victronenergy.settings,/Settings/CGwacs/AcPowerSetPoint,d,W,2703,int16,0.01,W
 com.victronenergy.settings,/Settings/CGwacs/MaxChargePercentage,d,%,2701,uint16,1,W
 com.victronenergy.settings,/Settings/CGwacs/MaxDischargePercentage,d,%,2702,uint16,1,W
-com.victronenergy.settings,/Settings/CGwacs/MaxDischargePower,d,W,2704,int16,0.1,W
+com.victronenergy.settings,/Settings/CGwacs/MaxDischargePower,d,W,2704,int16_ul,0.1,W
 com.victronenergy.settings,/Settings/SystemSetup/MaxChargeCurrent,d,A,2705,int16,1,W
 com.victronenergy.settings,/Settings/CGwacs/MaxFeedInPower,d,W,2706,int16,0.01,W
 com.victronenergy.settings,/Settings/CGwacs/OvervoltageFeedIn,i,0=Don't feed excess DC-coupled PV into grid;1=Feed excess DC-coupled PV into the grid,2707,uint16,1,W

--- a/mappings.cpp
+++ b/mappings.cpp
@@ -666,7 +666,12 @@ void Mappings::DataIterator::next()
 	++mCurrent;
 	int newAddress = oldAddress + d->size;
 
-	if (mCurrent == mMappings->mDBusModbusMap.end() || mCurrent.key() != newAddress) {
+if (mCurrent == mMappings->mDBusModbusMap.end()) {
+            setError(AddressError, QString("Modbus address %1 is not registered").arg(newAddress));
+            return;
+    }
+
+    if (mCurrent.key() != newAddress) {
 		setError(AddressError, QString("Modbus address %1 is not registered").arg(newAddress));
 		return;
 	}

--- a/mappings.cpp
+++ b/mappings.cpp
@@ -593,21 +593,16 @@ Mappings::DataIterator::DataIterator(const Mappings *mappings, int address, int 
 		return;
 	}
 
-	mCurrent = mMappings->mDBusModbusMap.lowerBound(address);
-	if (mCurrent == mMappings->mDBusModbusMap.end()) {
-		setError(StartAddressError, QString("Modbus address %1 is not registered").arg(address));
-		return;
-	}
-	Q_ASSERT(mCurrent.key() >= address);
-	if (mCurrent.key() > address) {
-		if (mCurrent == mMappings->mDBusModbusMap.begin()) {
-			setError(StartAddressError, QString("Modbus address %1 is not registered").arg(address));
-			return;
-		}
-		// Note that in a QMap (unlike a QHash) all elements are ordered by key,
-		// so --mCurrent will move the iterator to the last element before it. This is
-		// the last value with key < modbusAddress.
-		--mCurrent;
+        mCurrent = mMappings->mDBusModbusMap.lowerBound(address);
+        if (mCurrent == mMappings->mDBusModbusMap.end() || mCurrent.key() > address) {
+                if (mCurrent == mMappings->mDBusModbusMap.begin()) {
+                        setError(StartAddressError, QString("Modbus address %1 is not registered").arg(address));
+                        return;
+                }
+                // Note that in a QMap (unlike a QHash) all elements are ordered by key,
+                // so --mCurrent will move the iterator to the last element before it. This is
+                // the last value with key < modbusAddress.
+                --mCurrent;
 		Q_ASSERT(mCurrent.key() < address);
 		if (mCurrent.key() + mCurrent.value()->size <= address) {
 			setError(StartAddressError, QString("Modbus address %1 is not registered").arg(address));

--- a/mappings.cpp
+++ b/mappings.cpp
@@ -247,6 +247,10 @@ quint16 Mappings::getValue(const QVariant &dbusValue, ModbusTypes modbusType, in
 	case mb_type_int16:
 		return convertFromDbus<qint16>(dbusValue, scaleFactor);
 	case mb_type_uint16:
+        case mb_type_int16_ul:
+                if (dbusValue.toDouble() == -1.0)
+                        return 0xFFFF;
+                return convertFromDbus<qint16>(dbusValue, scaleFactor);
 		return convertFromDbus<quint16>(dbusValue, scaleFactor);
 	case mb_type_int32:
 	{
@@ -384,6 +388,13 @@ void Mappings::setValues(MappingRequest *request)
 			case mb_type_int16:
 				dbusValue = convertToDbus(it.data()->dbusType, static_cast<qint16>(value),
 										  it.data()->scaleFactor);
+                        case mb_type_int16_ul:
+                                if (static_cast<qint16>(value) == -1)
+                                        dbusValue = -1.0;
+                                else
+                                        dbusValue = convertToDbus(it.data()->dbusType, static_cast<qint16>(value),
+                                                                                          it.data()->scaleFactor);
+                                break;
 				break;
 			case mb_type_uint16:
 				dbusValue = convertToDbus(it.data()->dbusType, static_cast<quint16>(value),
@@ -518,6 +529,8 @@ Mappings::ModbusTypes Mappings::convertModbusType(const QString &typeString)
 {
 	if (typeString == "int16")
 		return mb_type_int16;
+        if (typeString == "int16_ul")
+                return mb_type_int16_ul;
 	if (typeString == "uint16")
 		return mb_type_uint16;
 	if (typeString == "int32")

--- a/mappings.h
+++ b/mappings.h
@@ -56,14 +56,7 @@ private:
 		mb_type_int32,
 		mb_type_uint64,
 		mb_type_string,
-		mb_type_reserved
-	};
-
-	enum Permissions {
-		mb_perm_none,
-		mb_perm_read,
-		mb_perm_write
-	};
+                mb_type_int16_ul,
 
 	class Operation;
 	struct DBusModbusData {


### PR DESCRIPTION
Fixes a crash in  where  was accessed safely immediately after verifying that  was not  in a combined boolean/logical check, but in some edge cases or compiler behaviors could still be problematic. This change explicitly handles the  check first and returns.